### PR TITLE
Removed log spam

### DIFF
--- a/Scripts/VillagerVarietyMobilePerson.cs
+++ b/Scripts/VillagerVarietyMobilePerson.cs
@@ -217,7 +217,6 @@ namespace VillagerVariety
             int variant = Random.Range(0, VillagerVarietyMod.NUM_VARIANTS);
             string season = VillagerVarietyMod.SEASON_STRS[(int)DaggerfallUnity.Instance.WorldTime.Now.SeasonValue];
 
-            Debug.LogFormat("Setting up villager variant: {0:000}.{1}.{2}{3}", archive, personFaceRecordId, variant, season);
             AssignMeshAndMaterial(archive, personFaceRecordId, variant, season);
 
             // Setup animation state


### PR DESCRIPTION
Many times, users send me logs that look like this for hundreds of lines

![image](https://github.com/drcarademono/villager-variety/assets/5789925/40dc2f75-7438-40b1-b89c-d48bb5811353)

I'm removing this log for the next release. We can bring it back under an optional setting in the future if we ever find it useful